### PR TITLE
Add Nerd Font families to terminal font stack

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -376,7 +376,7 @@ export const App = () => {
     const themeConfig = themes[theme];
     const terminal = new Terminal({
       cursorBlink: true,
-      fontFamily: "'MesloLGS NF', 'MesloLGM NF', 'Hack Nerd Font', 'FiraCode Nerd Font', 'JetBrainsMono Nerd Font', 'DejaVuSansM Nerd Font', Menlo, Monaco, 'Courier New', monospace",
+      fontFamily: "'MesloLGS NF', 'MesloLGM NF', 'Hack Nerd Font', 'FiraCode Nerd Font', 'JetBrainsMono Nerd Font', 'DejaVu Sans Mono Nerd Font', Menlo, Monaco, 'Courier New', monospace",
       fontSize: initialFontSize,
       theme: themeConfig?.xterm ?? {
         background: "#0d1117",


### PR DESCRIPTION
### **User description**
## Summary
- Prioritize common Nerd Font families in the xterm.js font stack so Powerline symbols and extended glyphs render correctly when the user has a patched font installed
- Falls back gracefully to the existing Menlo/Monaco/Courier New chain when no Nerd Font is available

Closes #18

## Test plan
- [ ] Verify terminal renders normally without any Nerd Font installed (fallback to Menlo/Monaco)
- [ ] Install a Nerd Font (e.g. MesloLGS NF) and verify Powerline/glyph symbols render correctly
- [ ] Test on mobile Safari and Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Nerd Font families to terminal font stack

- Prioritize patched fonts for Powerline symbols rendering

- Gracefully fallback to Menlo/Monaco when unavailable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Terminal Font Stack"] -->|"Prioritize"| B["Nerd Fonts<br/>MesloLGS, Hack, FiraCode,<br/>JetBrainsMono, DejaVuSansM"]
  B -->|"Fallback"| C["System Fonts<br/>Menlo, Monaco, Courier New"]
  C -->|"Final Fallback"| D["Monospace"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Add Nerd Font families to xterm.js configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/App.tsx

<ul><li>Updated Terminal component fontFamily configuration<br> <li> Added five Nerd Font families before existing fallbacks<br> <li> Maintains backward compatibility with graceful degradation<br> <li> Enables proper rendering of Powerline symbols and extended glyphs</ul>


</details>


  </td>
  <td><a href="https://github.com/DagsHub/tmux-mobile/pull/28/files#diff-79bcbb9a0bef28b6c9a1f83cf697ec484f372c36662cf58fc6e3420560bbe487">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Technical Implementation

The fontFamily configuration in the xterm.js Terminal initialization has been updated to prepend six Nerd Font families to the existing fallback chain:

**Added Nerd Fonts (in priority order):**
1. MesloLGS NF
2. MesloLGM NF
3. Hack Nerd Font
4. FiraCode Nerd Font
5. JetBrainsMono Nerd Font
6. DejaVuSansM Nerd Font

The existing fallback chain (Menlo, Monaco, Courier New, monospace) remains at the end of the stack, ensuring graceful degradation on systems without any Nerd Font installed.

## Code Location

**File modified:** `src/frontend/App.tsx` (line 379)  
**Component affected:** Terminal initialization in the `App` component's `useEffect` hook

The change is a single-line modification to the `fontFamily` property of the xterm.js Terminal configuration object, with no modifications to other terminal options or application logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->