### PR TITLE
Fix: keep internal runtime logs silent unless debug log is enabled

### DIFF
--- a/src/backend/util/file-logger.ts
+++ b/src/backend/util/file-logger.ts
@@ -10,7 +10,7 @@ const DEFAULT_LOGGER: Pick<Console, "log" | "error"> = {
 
 const serialize = (value: unknown): string => {
   if (value instanceof Error) {
-    return `${value.name}: ${value.message}`;
+    return value.stack ?? `${value.name}: ${value.message}`;
   }
   if (typeof value === "string") {
     return value;

--- a/tests/backend/file-logger.test.ts
+++ b/tests/backend/file-logger.test.ts
@@ -34,4 +34,18 @@ describe("file logger", () => {
     expect(content).toContain("[INFO] hello {\"ok\":true}");
     expect(content).toContain("[ERROR] boom");
   });
+
+  test("writes error stack trace details to debug log files", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tmux-mobile-logger-"));
+    const logPath = path.join(tempRoot, "debug.log");
+    const logger = createLogger(logPath);
+    const error = new Error("explode");
+
+    error.stack = "Error: explode\n    at test-frame";
+    logger.error(error);
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("Error: explode");
+    expect(content).toContain("at test-frame");
+  });
 });


### PR DESCRIPTION
### **User description**
## Summary
- make internal backend logger a no-op when no debug log file path is configured
- keep file-backed logging behavior unchanged when --debug-log or TMUX_MOBILE_DEBUG_LOG is set
- add backend unit tests covering silent default behavior and file logging behavior

## Testing
- npx vitest run tests/backend/file-logger.test.ts
- npm test

Closes #37


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replace console with no-op logger when debug log disabled

- Prevent internal runtime logs from appearing in stdout/stderr

- Add comprehensive unit tests for logger behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["createLogger called"] --> B{"logFilePath provided?"}
  B -->|No| C["Return NOOP_LOGGER"]
  B -->|Yes| D["Return file-backed logger"]
  C --> E["Silent operation"]
  D --> F["Write to file"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file-logger.ts</strong><dd><code>Implement no-op logger for silent default behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend/util/file-logger.ts

<ul><li>Added <code>NOOP_LOGGER</code> constant with no-op implementations of <code>log</code> and <code>error</code> <br>methods<br> <li> Changed <code>createLogger</code> to return <code>NOOP_LOGGER</code> instead of <code>console</code> when no <br>log file path is provided<br> <li> Maintains existing file-backed logging behavior when debug log path is <br>configured</ul>


</details>


  </td>
  <td><a href="https://github.com/DagsHub/tmux-mobile/pull/38/files#diff-75f624855a95aedc72142a251c5fae851cc79779c0bc926bc10322e1be1989a3">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file-logger.test.ts</strong><dd><code>Add unit tests for logger silent and file modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/backend/file-logger.test.ts

<ul><li>Added new test file with comprehensive test suite for file logger<br> <li> Test verifies logger is silent when no debug log file is configured<br> <li> Test verifies logs are written to file with proper formatting when <br>path is provided<br> <li> Uses vitest spies and temporary directories for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/DagsHub/tmux-mobile/pull/38/files#diff-e67cf6eacb0e599be374f483dff47a5e4aeaa2414711632c73ae94648528621d">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

**src/backend/util/file-logger.ts**

- Introduces a NOOP-style DEFAULT_LOGGER that silences logger.log while still delegating logger.error to console.error so errors continue to be reported to stderr by default.
- serialize now includes Error.stack when present (falls back to "name: message"), so error stack traces are preserved for file-backed logging.
- createLogger returns DEFAULT_LOGGER when no logFilePath is provided; when a path is provided behavior is unchanged (creates directories, appends timestamped lines with [INFO] or [ERROR]).

**tests/backend/file-logger.test.ts** (new file)

Adds tests covering:
1. Silent default behavior: logger.log is suppressed and logger.error is forwarded to console.error when no log file is configured.
2. File logging behavior: messages are written to the configured log file with expected formatting.
3. Error stack tracing: error.stack contents are written into the debug log.

No public API or exported-signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->