### PR TITLE
Isolate mobile focus via per-client grouped sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ npm start
 - If you do not provide `--password`, a random password is generated.
 - Password is printed separately (not in URL query parameters).
 - You can disable password checks for trusted local workflows with `--no-require-password`.
+- Mobile clients attach through dedicated grouped tmux sessions, so window focus is independent per client.
+- Pane focus and process/input state are still shared when two clients work in the same window/pane.
 - Full security architecture, risk model, and operational guidance: [SECURITY.md](./SECURITY.md)
 
 ## Versioning

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,9 @@ Current posture:
 4. Browser loads app and opens two sockets:
    - `/ws/control` for JSON control/state
    - `/ws/terminal` for terminal stream
-5. First message on each socket must be `{ type: "auth", token, password }`.
+5. First message on each socket must be auth:
+   - control socket: `{ type: "auth", token, password }`
+   - terminal socket: `{ type: "auth", token, password, clientId }` where `clientId` comes from control `auth_ok`
 6. After auth success, client can fully control the tmux session and read terminal output.
 
 ## Authentication And Authorization
@@ -79,6 +81,8 @@ Current posture:
 - All-or-nothing.
 - Once authenticated, client can issue all control operations and terminal input.
 - No role separation (read-only vs control).
+- tmux-mobile creates a dedicated grouped tmux session per authenticated control client to isolate window focus.
+- Pane focus inside the same shared window remains shared by tmux semantics.
 
 ## Credential Lifecycle And Storage
 

--- a/src/backend/tmux/cli-executor.ts
+++ b/src/backend/tmux/cli-executor.ts
@@ -111,6 +111,10 @@ export class TmuxCliExecutor implements TmuxGateway {
     await this.runTmux(["new-session", "-d", "-s", name]);
   }
 
+  public async createGroupedSession(name: string, targetSession: string): Promise<void> {
+    await this.runTmux(["new-session", "-d", "-s", name, "-t", targetSession]);
+  }
+
   public async killSession(name: string): Promise<void> {
     await this.runTmux(["kill-session", "-t", name]);
   }

--- a/src/backend/tmux/types.ts
+++ b/src/backend/tmux/types.ts
@@ -11,6 +11,7 @@ export interface TmuxGateway {
   listWindows(session: string): Promise<Omit<TmuxWindowState, "panes">[]>;
   listPanes(session: string, windowIndex: number): Promise<TmuxPaneState[]>;
   createSession(name: string): Promise<void>;
+  createGroupedSession(name: string, targetSession: string): Promise<void>;
   killSession(name: string): Promise<void>;
   switchClient(session: string): Promise<void>;
   newWindow(session: string): Promise<void>;

--- a/src/backend/types/protocol.ts
+++ b/src/backend/types/protocol.ts
@@ -1,5 +1,5 @@
 export type ControlClientMessage =
-  | { type: "auth"; token?: string; password?: string }
+  | { type: "auth"; token?: string; password?: string; clientId?: string }
   | { type: "select_session"; session: string }
   | { type: "new_session"; name: string }
   | { type: "new_window"; session: string }

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -225,12 +225,14 @@ export const App = () => {
     return reason;
   };
 
-  const openTerminalSocket = (passwordValue: string): void => {
+  const openTerminalSocket = (passwordValue: string, clientId: string): void => {
     terminalSocketRef.current?.close();
 
     const socket = new WebSocket(`${wsOrigin}/ws/terminal`);
     socket.onopen = () => {
-      socket.send(JSON.stringify({ type: "auth", token, password: passwordValue || undefined }));
+      socket.send(
+        JSON.stringify({ type: "auth", token, password: passwordValue || undefined, clientId })
+      );
       setStatusMessage("terminal connected");
       if (fitAddonRef.current && terminalRef.current) {
         fitAddonRef.current.fit();
@@ -281,7 +283,7 @@ export const App = () => {
           } else {
             localStorage.removeItem("tmux-mobile-password");
           }
-          openTerminalSocket(passwordValue);
+          openTerminalSocket(passwordValue, message.clientId);
           return;
         case "auth_error":
           setErrorMessage(message.reason);

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -115,7 +115,9 @@ test.describe("tmux-mobile browser behavior", () => {
       await expect(page.getByTestId("session-picker-overlay")).toHaveCount(0);
       await expect(page.locator(".top-title")).toContainText("Window: 0: shell");
 
-      await expect.poll(() => server.ptyFactory.lastSpawnedSession).toBe("work");
+      await expect
+        .poll(() => server.ptyFactory.lastSpawnedSession?.startsWith("tmux-mobile-client-") ?? false)
+        .toBe(true);
     });
   });
 
@@ -194,7 +196,9 @@ test.describe("tmux-mobile browser behavior", () => {
 
       await expect(page.getByTestId("session-picker-overlay")).toHaveCount(0);
       await expect(page.locator(".top-title")).toContainText("Window: 0: shell");
-      await expect.poll(() => server.ptyFactory.lastSpawnedSession).toBe("dev");
+      await expect
+        .poll(() => server.ptyFactory.lastSpawnedSession?.startsWith("tmux-mobile-client-") ?? false)
+        .toBe(true);
     });
   });
 });

--- a/tests/harness/fakeTmux.ts
+++ b/tests/harness/fakeTmux.ts
@@ -116,6 +116,24 @@ export class FakeTmuxGateway implements TmuxGateway {
     this.sessions.push(buildDefaultSession(name));
   }
 
+  public async createGroupedSession(name: string, targetSession: string): Promise<void> {
+    this.calls.push(`createGroupedSession:${name}:${targetSession}`);
+    if (this.sessions.some((session) => session.name === name)) {
+      return;
+    }
+    const target = this.findSession(targetSession);
+    this.sessions.push({
+      name,
+      attached: false,
+      windows: target.windows.map((window) => ({
+        index: window.index,
+        name: window.name,
+        active: window.active,
+        panes: window.panes.map((pane) => ({ ...pane }))
+      }))
+    });
+  }
+
   public async killSession(name: string): Promise<void> {
     this.calls.push(`killSession:${name}`);
     this.sessions = this.sessions.filter((session) => session.name !== name);


### PR DESCRIPTION
Closes #54

## Summary
- isolate each authenticated control client behind its own tmux runtime and dedicated grouped tmux session (`tmux-mobile-client-<clientId>`)
- bind terminal websocket auth to a control `clientId` so terminal I/O routes only to that client runtime
- route session/window control mutations to the dedicated mobile session instead of mutating the operator's base session focus
- add grouped-session creation support to `TmuxGateway` and fake harnesses
- document updated handshake + focus semantics in `README.md` and `SECURITY.md`

## Testing
- `npx vitest run tests/integration/server.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Implementation Details

**Context and Runtime Architecture:**
- Extended `ControlContext` with `runtime`, `baseSession`, `attachedSession` fields, and a `terminalClients` set to track all terminal WebSocket connections for a control client.
- Extended `DataContext` with `controlClientId` and `controlContext` references to bind terminal I/O to specific control client contexts.
- Introduced per-context `TerminalRuntime` creation via `getOrCreateRuntime(context)`, replacing global runtime usage to enable independent PTY processes and data forwarding per authenticated control client.

**Mobile Session Lifecycle:**
- Implemented `attachControlToBaseSession` to create or reuse a mobile session named `tmux-mobile-client-<clientId>` grouped to the operator's base session.
- Added mobile session cleanup via `shutdownControlContext(context)`: closes all terminal sockets, clears the terminalClients set, shuts down the runtime, and kills the attached mobile session if present.
- Mobile session naming helpers (`buildMobileSessionName`, `isManagedMobileSession`, `MOBILE_SESSION_PREFIX`) enable filtering managed sessions from session picker discovery.

**Protocol and Authentication:**
- Extended terminal socket authentication from `{token, password}` to `{token, password, clientId}`, with `clientId` supplied by the control flow after successful auth.
- Terminal connection now requires a valid `clientId` mapped to an authenticated `ControlContext`, with validation of `controlContext.authed` and unauthorized session closure for terminals lacking proper control context.

**Control Operations Routing:**
- Refactored `runControlMutation` and session/window control handlers to operate via context, ensuring mutations target the correct runtime and mobile session (not the operator's base session).
- Binary/text message handling routes through `controlContext?.runtime` for proper data forwarding to the correct terminal client.

**Test Harness and Coverage:**
- Updated `FakeTmuxGateway` with `createGroupedSession(name, targetSession)` to simulate grouped session creation in tests by cloning window/pane structure from a target session.
- Added `authControl` helper in integration tests to standardize control WebSocket authentication and return `clientId` and `attachedSession` for terminal binding.
- New integration tests verify terminal auth binding requires proper `clientId` and returns "unauthorized" error without valid control context; runtime isolation enforces separate PTY processes per authenticated client with data routed only to the correct terminal connection.
- E2E tests updated to verify that spawned sessions match the `tmux-mobile-client-*` prefix rather than asserting concrete session names.

**Frontend Integration:**
- Terminal WebSocket initialization now accepts and propagates `clientId` from the control auth response (`auth_ok` message) into the terminal auth payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->