### PR TITLE
Restore pane and zoom state on reconnect

### DIFF
--- a/src/backend/tmux/cli-executor.ts
+++ b/src/backend/tmux/cli-executor.ts
@@ -7,7 +7,8 @@ import { withoutTmuxEnv } from "../util/env.js";
 const execFileAsync = promisify(execFile);
 
 const SESSION_FMT = "#{session_name}\t#{session_attached}\t#{session_windows}";
-const WINDOW_FMT = "#{window_index}\t#{window_name}\t#{window_active}\t#{window_panes}";
+const WINDOW_FMT =
+  "#{window_index}\t#{window_name}\t#{window_active}\t#{window_zoomed_flag}\t#{window_panes}";
 const PANE_FMT = "#{pane_index}\t#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}x#{pane_height}";
 
 interface TmuxCliExecutorOptions {

--- a/src/backend/tmux/parser.ts
+++ b/src/backend/tmux/parser.ts
@@ -26,11 +26,12 @@ export const parseWindows = (raw: string): Omit<TmuxWindowState, "panes">[] =>
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [index, name, active, panes] = splitLine(line);
+      const [index, name, active, zoomed, panes] = splitLine(line);
       return {
         index: Number.parseInt(index, 10),
         name,
         active: active === "1",
+        zoomed: zoomed === "1",
         paneCount: Number.parseInt(panes, 10)
       };
     });

--- a/src/backend/types/protocol.ts
+++ b/src/backend/types/protocol.ts
@@ -31,6 +31,7 @@ export interface TmuxWindowState {
   index: number;
   name: string;
   active: boolean;
+  zoomed: boolean;
   paneCount: number;
   panes: TmuxPaneState[];
 }

--- a/src/frontend/types/protocol.ts
+++ b/src/frontend/types/protocol.ts
@@ -17,6 +17,7 @@ export interface TmuxWindowState {
   index: number;
   name: string;
   active: boolean;
+  zoomed: boolean;
   paneCount: number;
   panes: TmuxPaneState[];
 }

--- a/tests/backend/parser.test.ts
+++ b/tests/backend/parser.test.ts
@@ -11,8 +11,8 @@ describe("tmux parser", () => {
   });
 
   test("parses windows and panes", () => {
-    const windows = parseWindows("0\tbash\t1\t2");
-    expect(windows[0]).toEqual({ index: 0, name: "bash", active: true, paneCount: 2 });
+    const windows = parseWindows("0\tbash\t1\t0\t2");
+    expect(windows[0]).toEqual({ index: 0, name: "bash", active: true, zoomed: false, paneCount: 2 });
 
     const panes = parsePanes("0\t%1\tbash\t1\t120x30");
     expect(panes[0]).toEqual({

--- a/tests/harness/fakeTmux.ts
+++ b/tests/harness/fakeTmux.ts
@@ -15,6 +15,7 @@ interface WindowNode {
   index: number;
   name: string;
   active: boolean;
+  zoomed: boolean;
   panes: PaneNode[];
 }
 
@@ -42,6 +43,7 @@ const buildDefaultSession = (name: string): SessionNode => ({
       index: 0,
       name: "shell",
       active: true,
+      zoomed: false,
       panes: [
         {
           index: 0,
@@ -88,6 +90,7 @@ export class FakeTmuxGateway implements TmuxGateway {
         index: window.index,
         name: window.name,
         active: window.active,
+        zoomed: window.zoomed,
         paneCount: window.panes.length
       }))
     );
@@ -129,6 +132,7 @@ export class FakeTmuxGateway implements TmuxGateway {
         index: window.index,
         name: window.name,
         active: window.active,
+        zoomed: window.zoomed,
         panes: window.panes.map((pane) => ({ ...pane }))
       }))
     });
@@ -158,6 +162,7 @@ export class FakeTmuxGateway implements TmuxGateway {
       index: nextIndex + 1,
       name: `win-${nextIndex + 1}`,
       active: true,
+      zoomed: false,
       panes: [
         {
           index: 0,
@@ -226,6 +231,8 @@ export class FakeTmuxGateway implements TmuxGateway {
 
   public async zoomPane(paneId: string): Promise<void> {
     this.calls.push(`zoomPane:${paneId}`);
+    const { window } = this.findByPane(paneId);
+    window.zoomed = !window.zoomed;
   }
 
   public async capturePane(paneId: string, lines: number): Promise<string> {


### PR DESCRIPTION
## Summary
- persist and reuse control clientId across reconnects
- track per-client reconnect state (base session, active pane, zoomed state)
- best-effort restore pane and zoom state after reattach
- include tmux window zoom state in protocol/parsing and update test harness

## Testing
- npm run typecheck
- npm test

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Implementation Details

The reconnection mechanism is built around a per-client `ReconnectState` structure that persists three pieces of state:
- **baseSession**: The tmux session the client was last attached to
- **paneId**: The specific pane that was active
- **zoomed**: Whether the pane/window was in zoomed state

### Client Identity and Session Reuse
- A `normalizeClientId` function sanitizes incoming clientId values from the authentication message
- When a client reconnects with an existing clientId, the server forcefully closes any previous WebSocket connection for that identity and cleans up its context, then reuses the clientId for the new connection
- This prevents duplicate control contexts and enables true session continuity

### State Tracking and Restoration
- The server tracks state changes through control message handlers (`select_pane` and `zoom_pane` mutations), storing them in `rememberReconnectState`
- On disconnect, the current `baseSession` is persisted so subsequent reconnects can default to it
- The `tryRestoreClientView` function applies stored state after attachment, with careful error handling:
  - Attempts `selectPane` with the remembered paneId
  - Only if successful, checks and restores zoom state by comparing stored vs. current window zoom status
  - Silently falls back to the current view if any restoration step fails

### Frontend Client ID Persistence
- The frontend persists a client-generated or server-assigned clientId to localStorage (key: "tmux-mobile-client-id")
- Sends this clientId in the control channel authentication payload
- Stores the server-confirmed clientId on successful `auth_ok` response

### Test Harness and Protocol Updates
- The fake tmux harness now tracks per-window zoom state and updates it during `zoomPane` operations
- Protocol interfaces updated to include `zoomed: boolean` on `TmuxWindowState` at both frontend and backend
- New integration tests verify clientId preservation and pane/zoom restoration across reconnects, including best-effort fallback when the remembered pane is no longer available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->