### PR TITLE
feat: make pane zoom sticky across pane switches

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -77,10 +77,17 @@ const summarizeClientMessage = (message: ControlClientMessage): string => {
     return JSON.stringify({
       type: message.type,
       tokenPresent: Boolean(message.token),
-      passwordPresent: Boolean(message.password)
+      passwordPresent: Boolean(message.password),
+      clientIdPresent: Boolean(message.clientId)
     });
   }
-  return JSON.stringify(message);
+  if (message.type === "send_compose") {
+    return JSON.stringify({
+      type: message.type,
+      textLength: message.text.length
+    });
+  }
+  return JSON.stringify({ type: message.type });
 };
 
 const summarizeState = (state: TmuxStateSnapshot): string => {

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -192,7 +192,7 @@ export const createTmuxMobileServer = (
         return;
       case "select_pane":
         await deps.tmux.selectPane(message.paneId);
-        if (message.stickyZoom) {
+        if (message.stickyZoom === true && !(await deps.tmux.isPaneZoomed(message.paneId))) {
           await deps.tmux.zoomPane(message.paneId);
         }
         return;

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -192,6 +192,9 @@ export const createTmuxMobileServer = (
         return;
       case "select_pane":
         await deps.tmux.selectPane(message.paneId);
+        if (message.stickyZoom) {
+          await deps.tmux.zoomPane(message.paneId);
+        }
         return;
       case "split_pane":
         await deps.tmux.splitWindow(message.paneId, message.orientation);

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -279,6 +279,13 @@ export const createTmuxMobileServer = (
           throw new Error("no attached session");
         }
         await deps.tmux.selectWindow(attachedSession, message.windowIndex);
+        if (message.stickyZoom === true) {
+          const panes = await deps.tmux.listPanes(attachedSession, message.windowIndex);
+          const activePane = panes.find((pane) => pane.active) ?? panes[0];
+          if (activePane && !(await deps.tmux.isPaneZoomed(activePane.id))) {
+            await deps.tmux.zoomPane(activePane.id);
+          }
+        }
         return;
       case "kill_window":
         if (!attachedSession) {

--- a/src/backend/state/state-monitor.ts
+++ b/src/backend/state/state-monitor.ts
@@ -60,8 +60,8 @@ export class TmuxStateMonitor {
     const gen = this.forceGeneration;
     const snapshot = await buildSnapshot(this.tmux);
 
-    // A forcePublish happened while we were building; discard stale data.
-    if (!force && gen !== this.forceGeneration) {
+    // A newer forcePublish happened while we were building; discard stale data.
+    if (gen !== this.forceGeneration) {
       return;
     }
 

--- a/src/backend/tmux/cli-executor.ts
+++ b/src/backend/tmux/cli-executor.ts
@@ -8,7 +8,8 @@ const execFileAsync = promisify(execFile);
 
 const SESSION_FMT = "#{session_name}\t#{session_attached}\t#{session_windows}";
 const WINDOW_FMT = "#{window_index}\t#{window_name}\t#{window_active}\t#{window_panes}";
-const PANE_FMT = "#{pane_index}\t#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}x#{pane_height}";
+const PANE_FMT =
+  "#{pane_index}\t#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}x#{pane_height}\t#{window_zoomed_flag}";
 
 interface TmuxCliExecutorOptions {
   socketName?: string;

--- a/src/backend/tmux/cli-executor.ts
+++ b/src/backend/tmux/cli-executor.ts
@@ -148,6 +148,11 @@ export class TmuxCliExecutor implements TmuxGateway {
     await this.runTmux(["resize-pane", "-Z", "-t", paneId]);
   }
 
+  public async isPaneZoomed(paneId: string): Promise<boolean> {
+    const output = await this.runTmux(["display-message", "-p", "-t", paneId, "#{window_zoomed_flag}"]);
+    return output.trim() === "1";
+  }
+
   public async capturePane(paneId: string, lines: number): Promise<string> {
     return this.runTmux(["capture-pane", "-t", paneId, "-p", "-S", `-${lines}`]);
   }

--- a/src/backend/tmux/cli-executor.ts
+++ b/src/backend/tmux/cli-executor.ts
@@ -8,8 +8,9 @@ const execFileAsync = promisify(execFile);
 
 const SESSION_FMT = "#{session_name}\t#{session_attached}\t#{session_windows}";
 const WINDOW_FMT = "#{window_index}\t#{window_name}\t#{window_active}\t#{window_panes}";
+const ACTIVE_PANE_ZOOM_FMT = "#{?#{&&:#{window_zoomed_flag},#{pane_active}},1,0}";
 const PANE_FMT =
-  "#{pane_index}\t#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}x#{pane_height}\t#{window_zoomed_flag}";
+  `#{pane_index}\t#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}x#{pane_height}\t${ACTIVE_PANE_ZOOM_FMT}`;
 
 interface TmuxCliExecutorOptions {
   socketName?: string;
@@ -153,8 +154,8 @@ export class TmuxCliExecutor implements TmuxGateway {
   }
 
   public async isPaneZoomed(paneId: string): Promise<boolean> {
-    const output = await this.runTmux(["display-message", "-p", "-t", paneId, "#{window_zoomed_flag}"]);
-    return output.trim() === "1";
+    const output = await this.runTmux(["display-message", "-p", "-t", paneId, ACTIVE_PANE_ZOOM_FMT]);
+    return output === "1";
   }
 
   public async capturePane(paneId: string, lines: number): Promise<string> {

--- a/src/backend/tmux/parser.ts
+++ b/src/backend/tmux/parser.ts
@@ -41,7 +41,7 @@ export const parsePanes = (raw: string): TmuxPaneState[] =>
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [index, id, currentCommand, active, dimensions] = splitLine(line);
+      const [index, id, currentCommand, active, dimensions, zoomed] = splitLine(line);
       const [width, height] = dimensions.split("x");
       return {
         index: Number.parseInt(index, 10),
@@ -49,6 +49,7 @@ export const parsePanes = (raw: string): TmuxPaneState[] =>
         currentCommand,
         active: active === "1",
         width: Number.parseInt(width, 10),
-        height: Number.parseInt(height, 10)
+        height: Number.parseInt(height, 10),
+        zoomed: zoomed === "1"
       };
     });

--- a/src/backend/tmux/types.ts
+++ b/src/backend/tmux/types.ts
@@ -20,6 +20,7 @@ export interface TmuxGateway {
   killPane(paneId: string): Promise<void>;
   selectPane(paneId: string): Promise<void>;
   zoomPane(paneId: string): Promise<void>;
+  isPaneZoomed(paneId: string): Promise<boolean>;
   capturePane(paneId: string, lines: number): Promise<string>;
 }
 

--- a/src/backend/types/protocol.ts
+++ b/src/backend/types/protocol.ts
@@ -5,7 +5,7 @@ export type ControlClientMessage =
   | { type: "new_window"; session: string }
   | { type: "select_window"; session: string; windowIndex: number }
   | { type: "kill_window"; session: string; windowIndex: number }
-  | { type: "select_pane"; paneId: string }
+  | { type: "select_pane"; paneId: string; stickyZoom?: boolean }
   | { type: "split_pane"; paneId: string; orientation: "h" | "v" }
   | { type: "kill_pane"; paneId: string }
   | { type: "zoom_pane"; paneId: string }

--- a/src/backend/types/protocol.ts
+++ b/src/backend/types/protocol.ts
@@ -25,6 +25,7 @@ export interface TmuxPaneState {
   active: boolean;
   width: number;
   height: number;
+  zoomed: boolean;
 }
 
 export interface TmuxWindowState {

--- a/src/backend/types/protocol.ts
+++ b/src/backend/types/protocol.ts
@@ -3,7 +3,7 @@ export type ControlClientMessage =
   | { type: "select_session"; session: string }
   | { type: "new_session"; name: string }
   | { type: "new_window"; session: string }
-  | { type: "select_window"; session: string; windowIndex: number }
+  | { type: "select_window"; session: string; windowIndex: number; stickyZoom?: boolean }
   | { type: "kill_window"; session: string; windowIndex: number }
   | { type: "select_pane"; paneId: string; stickyZoom?: boolean }
   | { type: "split_pane"; paneId: string; orientation: "h" | "v" }

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -717,11 +717,11 @@ export const App = () => {
                         className={pane.active ? "active" : ""}
                       >
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
-                        {pane.active && pane.zoomed ? (
+                        {pane.active ? (
                           <span
-                            className="pane-zoom-indicator"
-                            title="Active pane is zoomed"
-                            aria-label="Pane zoom: on"
+                            className={`pane-zoom-indicator${pane.zoomed ? " on" : ""}`}
+                            title={pane.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
+                            aria-label={`Pane zoom: ${pane.zoomed ? "on" : "off"}`}
                             data-testid="active-pane-zoom-indicator"
                           >
                             🔍

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -717,11 +717,11 @@ export const App = () => {
                         className={pane.active ? "active" : ""}
                       >
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
-                        {pane.active ? (
+                        {pane.active && pane.zoomed ? (
                           <span
-                            className={`pane-zoom-indicator${pane.zoomed || stickyZoom ? " on" : ""}`}
-                            title={pane.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
-                            aria-label={`Pane zoom: ${pane.zoomed ? "on" : "off"}`}
+                            className="pane-zoom-indicator"
+                            title="Active pane is zoomed"
+                            aria-label="Pane zoom: on"
                             data-testid="active-pane-zoom-indicator"
                           >
                             🔍

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -32,6 +32,17 @@ const getPreferredTerminalFontSize = (): number => {
   return window.matchMedia("(max-width: 768px), (pointer: coarse)").matches ? 12 : 14;
 };
 
+const getInitialStickyZoom = (): boolean => {
+  const stored = localStorage.getItem("tmux-mobile-sticky-zoom");
+  if (stored === "true") {
+    return true;
+  }
+  if (stored === "false") {
+    return false;
+  }
+  return window.matchMedia("(max-width: 768px)").matches;
+};
+
 const parseMessage = (raw: string): ControlServerMessage | null => {
   try {
     return JSON.parse(raw) as ControlServerMessage;
@@ -79,9 +90,7 @@ export const App = () => {
     localStorage.getItem("tmux-mobile-toolbar-expanded") === "true"
   );
   const [toolbarDeepExpanded, setToolbarDeepExpanded] = useState(false);
-  const [stickyZoom, setStickyZoom] = useState(
-    localStorage.getItem("tmux-mobile-sticky-zoom") === "true"
-  );
+  const [stickyZoom, setStickyZoom] = useState(getInitialStickyZoom);
 
   const activeSession: TmuxSessionState | undefined = useMemo(() => {
     const selected = snapshot.sessions.find((session) => session.name === attachedSession);
@@ -491,6 +500,14 @@ export const App = () => {
             aria-label={`Status: ${topStatus.label}`}
             data-testid="top-status-indicator"
           />
+          <span
+            className={`top-zoom-indicator${activePane?.zoomed ? " on" : ""}`}
+            title={activePane?.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
+            aria-label={`Pane zoom: ${activePane?.zoomed ? "on" : "off"}`}
+            data-testid="top-zoom-indicator"
+          >
+            ⛶
+          </span>
           <button className="top-btn" onClick={() => requestScrollback(serverConfig?.scrollbackLines ?? 1000)}>
             Scroll
           </button>
@@ -698,6 +715,16 @@ export const App = () => {
                         className={pane.active ? "active" : ""}
                       >
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
+                        {pane.active ? (
+                          <span
+                            className={`pane-zoom-indicator${pane.zoomed ? " on" : ""}`}
+                            title={pane.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
+                            aria-label={`Pane zoom: ${pane.zoomed ? "on" : "off"}`}
+                            data-testid="active-pane-zoom-indicator"
+                          >
+                            ⛶
+                          </span>
+                        ) : null}
                       </button>
                     </li>
                   ))

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -79,6 +79,9 @@ export const App = () => {
     localStorage.getItem("tmux-mobile-toolbar-expanded") === "true"
   );
   const [toolbarDeepExpanded, setToolbarDeepExpanded] = useState(false);
+  const [stickyZoom, setStickyZoom] = useState(
+    localStorage.getItem("tmux-mobile-sticky-zoom") === "true"
+  );
 
   const activeSession: TmuxSessionState | undefined = useMemo(() => {
     const selected = snapshot.sessions.find((session) => session.name === attachedSession);
@@ -440,6 +443,11 @@ export const App = () => {
     localStorage.setItem("tmux-mobile-toolbar-expanded", toolbarExpanded ? "true" : "false");
   }, [toolbarExpanded]);
 
+  // Persist sticky zoom state
+  useEffect(() => {
+    localStorage.setItem("tmux-mobile-sticky-zoom", stickyZoom ? "true" : "false");
+  }, [stickyZoom]);
+
   const submitPassword = (): void => {
     setPasswordErrorMessage("");
     openControlSocket(password);
@@ -682,7 +690,11 @@ export const App = () => {
                 ? activeWindow.panes.map((pane) => (
                     <li key={pane.id}>
                       <button
-                        onClick={() => sendControl({ type: "select_pane", paneId: pane.id })}
+                        onClick={() => sendControl({
+                          type: "select_pane",
+                          paneId: pane.id,
+                          ...(stickyZoom ? { stickyZoom: true } : {})
+                        })}
                         className={pane.active ? "active" : ""}
                       >
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
@@ -719,6 +731,13 @@ export const App = () => {
               disabled={!activePane || !activeWindow || activeWindow.paneCount <= 1}
             >
               Zoom Pane
+            </button>
+            <button
+              className={`drawer-section-action${stickyZoom ? " active" : ""}`}
+              onClick={() => setStickyZoom((v) => !v)}
+              data-testid="sticky-zoom-toggle"
+            >
+              Sticky Zoom: {stickyZoom ? "On" : "Off"}
             </button>
 
             <button

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -712,7 +712,7 @@ export const App = () => {
                         onClick={() => sendControl({
                           type: "select_pane",
                           paneId: pane.id,
-                          ...(stickyZoom ? { stickyZoom: true } : {})
+                          ...(stickyZoom && !pane.active ? { stickyZoom: true } : {})
                         })}
                         className={pane.active ? "active" : ""}
                       >

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -500,14 +500,16 @@ export const App = () => {
             aria-label={`Status: ${topStatus.label}`}
             data-testid="top-status-indicator"
           />
-          <span
+          <button
             className={`top-zoom-indicator${activePane?.zoomed ? " on" : ""}`}
             title={activePane?.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
             aria-label={`Pane zoom: ${activePane?.zoomed ? "on" : "off"}`}
             data-testid="top-zoom-indicator"
+            onClick={() => activePane && sendControl({ type: "zoom_pane", paneId: activePane.id })}
+            disabled={!activePane || !activeWindow || activeWindow.paneCount <= 1}
           >
-            ⛶
-          </span>
+            🔍
+          </button>
           <button className="top-btn" onClick={() => requestScrollback(serverConfig?.scrollbackLines ?? 1000)}>
             Scroll
           </button>
@@ -717,12 +719,12 @@ export const App = () => {
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
                         {pane.active ? (
                           <span
-                            className={`pane-zoom-indicator${pane.zoomed ? " on" : ""}`}
+                            className={`pane-zoom-indicator${pane.zoomed || stickyZoom ? " on" : ""}`}
                             title={pane.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
                             aria-label={`Pane zoom: ${pane.zoomed ? "on" : "off"}`}
                             data-testid="active-pane-zoom-indicator"
                           >
-                            ⛶
+                            🔍
                           </span>
                         ) : null}
                       </button>

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -612,6 +612,18 @@ export const App = () => {
     terminalRef.current?.focus();
   };
 
+  const selectWindow = (windowState: TmuxWindowState): void => {
+    if (!activeSession) {
+      return;
+    }
+    sendControl({
+      type: "select_window",
+      session: activeSession.name,
+      windowIndex: windowState.index,
+      ...(stickyZoom && !windowState.active ? { stickyZoom: true } : {})
+    });
+  };
+
   return (
     <div className="app-shell">
       <header className="topbar">
@@ -809,13 +821,7 @@ export const App = () => {
                 ? activeSession.windowStates.map((windowState) => (
                     <li key={`${activeSession.name}-${windowState.index}`}>
                       <button
-                        onClick={() =>
-                          sendControl({
-                            type: "select_window",
-                            session: activeSession.name,
-                            windowIndex: windowState.index
-                          })
-                        }
+                        onClick={() => selectWindow(windowState)}
                         className={windowState.active ? "active" : ""}
                       >
                         {windowState.index}: {windowState.name} {windowState.active ? "*" : ""}
@@ -849,11 +855,11 @@ export const App = () => {
                         className={pane.active ? "active" : ""}
                       >
                         %{pane.index}: {pane.currentCommand} {pane.active ? "*" : ""}
-                        {pane.active ? (
+                        {pane.active && pane.zoomed ? (
                           <span
-                            className={`pane-zoom-indicator${pane.zoomed ? " on" : ""}`}
-                            title={pane.zoomed ? "Active pane is zoomed" : "Active pane is not zoomed"}
-                            aria-label={`Pane zoom: ${pane.zoomed ? "on" : "off"}`}
+                            className="pane-zoom-indicator on"
+                            title="Active pane is zoomed"
+                            aria-label="Pane zoom: on"
                             data-testid="active-pane-zoom-indicator"
                           >
                             🔍

--- a/src/frontend/styles/app.css
+++ b/src/frontend/styles/app.css
@@ -413,6 +413,26 @@ input {
   border-color: var(--status-pending-border);
 }
 
+.top-zoom-indicator {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 4px;
+  border: 1px solid var(--btn-border);
+  color: var(--text-muted);
+  background: rgba(148, 163, 184, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.top-zoom-indicator.on {
+  color: var(--accent);
+  border-color: var(--border-active);
+  background: var(--accent-glow);
+}
+
 .terminal-wrap {
   min-height: 0;
   padding: 0.3rem;
@@ -611,6 +631,27 @@ button.danger {
 .drawer button.active {
   background: var(--active-btn-bg);
   border-color: var(--border-active);
+}
+
+.pane-zoom-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.4rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 4px;
+  border: 1px solid var(--btn-border);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1;
+  vertical-align: text-bottom;
+}
+
+.pane-zoom-indicator.on {
+  color: var(--accent);
+  border-color: var(--border-active);
+  background: var(--accent-glow);
 }
 
 .drawer-grid {

--- a/src/frontend/styles/app.css
+++ b/src/frontend/styles/app.css
@@ -639,22 +639,9 @@ button.danger {
 }
 
 .pane-zoom-indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   margin-left: 0.4rem;
-  width: 1.2rem;
-  height: 1.2rem;
-  border-radius: 4px;
-  border: 1px solid transparent;
   font-size: 0.8rem;
-  line-height: 1;
   vertical-align: text-bottom;
-}
-
-.pane-zoom-indicator.on {
-  border-color: var(--border-active);
-  background: var(--accent-glow);
 }
 
 .drawer-grid {

--- a/src/frontend/styles/app.css
+++ b/src/frontend/styles/app.css
@@ -414,21 +414,26 @@ input {
 }
 
 .top-zoom-indicator {
-  width: 1rem;
-  height: 1rem;
+  width: 1.2rem;
+  height: 1.2rem;
   border-radius: 4px;
-  border: 1px solid var(--btn-border);
-  color: var(--text-muted);
-  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid transparent;
+  background: transparent;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   line-height: 1;
+  padding: 0;
+  cursor: pointer;
+}
+
+.top-zoom-indicator:disabled {
+  cursor: default;
+  opacity: 0.4;
 }
 
 .top-zoom-indicator.on {
-  color: var(--accent);
   border-color: var(--border-active);
   background: var(--accent-glow);
 }
@@ -638,18 +643,16 @@ button.danger {
   align-items: center;
   justify-content: center;
   margin-left: 0.4rem;
-  width: 1rem;
-  height: 1rem;
+  width: 1.2rem;
+  height: 1.2rem;
   border-radius: 4px;
-  border: 1px solid var(--btn-border);
-  color: var(--text-muted);
-  font-size: 0.72rem;
+  border: 1px solid transparent;
+  font-size: 0.8rem;
   line-height: 1;
   vertical-align: text-bottom;
 }
 
 .pane-zoom-indicator.on {
-  color: var(--accent);
   border-color: var(--border-active);
   background: var(--accent-glow);
 }

--- a/src/frontend/styles/app.css
+++ b/src/frontend/styles/app.css
@@ -639,9 +639,25 @@ button.danger {
 }
 
 .pane-zoom-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin-left: 0.4rem;
-  font-size: 0.8rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 4px;
+  border: 1px solid var(--btn-border);
+  color: var(--text-muted);
+  background: rgba(148, 163, 184, 0.08);
+  font-size: 0.72rem;
+  line-height: 1;
   vertical-align: text-bottom;
+}
+
+.pane-zoom-indicator.on {
+  color: var(--accent);
+  border-color: var(--border-active);
+  background: var(--accent-glow);
 }
 
 .drawer-grid {

--- a/src/frontend/types/protocol.ts
+++ b/src/frontend/types/protocol.ts
@@ -36,7 +36,7 @@ export type ControlClientMessage =
   | { type: "select_session"; session: string }
   | { type: "new_session"; name: string }
   | { type: "new_window"; session: string }
-  | { type: "select_window"; session: string; windowIndex: number }
+  | { type: "select_window"; session: string; windowIndex: number; stickyZoom?: boolean }
   | { type: "kill_window"; session: string; windowIndex: number }
   | { type: "select_pane"; paneId: string; stickyZoom?: boolean }
   | { type: "split_pane"; paneId: string; orientation: "h" | "v" }

--- a/src/frontend/types/protocol.ts
+++ b/src/frontend/types/protocol.ts
@@ -30,6 +30,20 @@ export interface TmuxStateSnapshot {
   capturedAt: string;
 }
 
+export type ControlClientMessage =
+  | { type: "auth"; token?: string; password?: string }
+  | { type: "select_session"; session: string }
+  | { type: "new_session"; name: string }
+  | { type: "new_window"; session: string }
+  | { type: "select_window"; session: string; windowIndex: number }
+  | { type: "kill_window"; session: string; windowIndex: number }
+  | { type: "select_pane"; paneId: string; stickyZoom?: boolean }
+  | { type: "split_pane"; paneId: string; orientation: "h" | "v" }
+  | { type: "kill_pane"; paneId: string }
+  | { type: "zoom_pane"; paneId: string }
+  | { type: "capture_scrollback"; paneId: string; lines?: number }
+  | { type: "send_compose"; text: string };
+
 export type ControlServerMessage =
   | { type: "auth_ok"; clientId: string; requiresPassword: boolean }
   | { type: "auth_error"; reason: string }

--- a/src/frontend/types/protocol.ts
+++ b/src/frontend/types/protocol.ts
@@ -32,7 +32,7 @@ export interface TmuxStateSnapshot {
 }
 
 export type ControlClientMessage =
-  | { type: "auth"; token?: string; password?: string }
+  | { type: "auth"; token?: string; password?: string; clientId?: string }
   | { type: "select_session"; session: string }
   | { type: "new_session"; name: string }
   | { type: "new_window"; session: string }

--- a/src/frontend/types/protocol.ts
+++ b/src/frontend/types/protocol.ts
@@ -11,6 +11,7 @@ export interface TmuxPaneState {
   active: boolean;
   width: number;
   height: number;
+  zoomed: boolean;
 }
 
 export interface TmuxWindowState {

--- a/tests/backend/parser.test.ts
+++ b/tests/backend/parser.test.ts
@@ -14,14 +14,15 @@ describe("tmux parser", () => {
     const windows = parseWindows("0\tbash\t1\t2");
     expect(windows[0]).toEqual({ index: 0, name: "bash", active: true, paneCount: 2 });
 
-    const panes = parsePanes("0\t%1\tbash\t1\t120x30");
+    const panes = parsePanes("0\t%1\tbash\t1\t120x30\t1");
     expect(panes[0]).toEqual({
       index: 0,
       id: "%1",
       currentCommand: "bash",
       active: true,
       width: 120,
-      height: 30
+      height: 30,
+      zoomed: true
     });
   });
 });

--- a/tests/backend/state-monitor.test.ts
+++ b/tests/backend/state-monitor.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 import { TmuxStateMonitor } from "../../src/backend/state/state-monitor.js";
 import { FakeTmuxGateway } from "../harness/fakeTmux.js";
 
+const delay = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
 describe("state monitor", () => {
   test("publishes only when state changes", async () => {
     const tmux = new FakeTmuxGateway(["main"]);
@@ -11,18 +15,65 @@ describe("state monitor", () => {
     const monitor = new TmuxStateMonitor(tmux, 50, onUpdate, onError);
     await monitor.start();
 
-    await new Promise((resolve) => setTimeout(resolve, 70));
+    await delay(70);
     const firstCount = onUpdate.mock.calls.length;
-    await new Promise((resolve) => setTimeout(resolve, 70));
+    await delay(70);
 
     expect(onUpdate.mock.calls.length).toBe(firstCount);
 
     await tmux.newWindow("main");
-    await new Promise((resolve) => setTimeout(resolve, 70));
+    await delay(70);
 
     expect(onUpdate.mock.calls.length).toBeGreaterThan(firstCount);
 
     monitor.stop();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("ignores stale tick snapshot that resolves after force publish", async () => {
+    const tmux = new FakeTmuxGateway(["main"]);
+    const [initialPane] = await tmux.listPanes("main", 0);
+    const onUpdate = vi.fn();
+    const onError = vi.fn();
+
+    let listPanesCalls = 0;
+    let secondTickStarted = false;
+    let releaseSecondTick: (() => void) | undefined;
+    const secondTickReleased = new Promise<void>((resolve) => {
+      releaseSecondTick = resolve;
+    });
+
+    const originalListPanes = tmux.listPanes.bind(tmux);
+    vi.spyOn(tmux, "listPanes").mockImplementation(async (...args) => {
+      listPanesCalls += 1;
+      if (listPanesCalls !== 2) {
+        return originalListPanes(...args);
+      }
+
+      const staleSnapshot = await originalListPanes(...args);
+      secondTickStarted = true;
+      await secondTickReleased;
+      return staleSnapshot;
+    });
+
+    const monitor = new TmuxStateMonitor(tmux, 5, onUpdate, onError);
+    await monitor.start();
+
+    await expect.poll(() => secondTickStarted).toBe(true);
+    await tmux.zoomPane(initialPane.id);
+    await monitor.forcePublish();
+    const forcePublishCalls = onUpdate.mock.calls.length;
+
+    releaseSecondTick?.();
+    await delay(20);
+    monitor.stop();
+
+    const zoomStatesAfterForcePublish = onUpdate.mock.calls
+      .slice(forcePublishCalls)
+      .map(([snapshot]) => snapshot.sessions[0].windowStates[0].panes[0].zoomed);
+
+    expect(zoomStatesAfterForcePublish).not.toContain(false);
+    expect(onUpdate).toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/tests/backend/state-monitor.test.ts
+++ b/tests/backend/state-monitor.test.ts
@@ -76,4 +76,54 @@ describe("state monitor", () => {
     expect(onUpdate).toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });
+
+  test("ignores stale forced snapshot that resolves after a newer force publish", async () => {
+    const tmux = new FakeTmuxGateway(["main"]);
+    const [initialPane] = await tmux.listPanes("main", 0);
+    const onUpdate = vi.fn();
+    const onError = vi.fn();
+
+    let listPanesCalls = 0;
+    let firstForceStarted = false;
+    let releaseFirstForce: (() => void) | undefined;
+    const firstForceReleased = new Promise<void>((resolve) => {
+      releaseFirstForce = resolve;
+    });
+
+    const originalListPanes = tmux.listPanes.bind(tmux);
+    vi.spyOn(tmux, "listPanes").mockImplementation(async (...args) => {
+      listPanesCalls += 1;
+      if (listPanesCalls !== 2) {
+        return originalListPanes(...args);
+      }
+
+      const staleSnapshot = await originalListPanes(...args);
+      firstForceStarted = true;
+      await firstForceReleased;
+      return staleSnapshot;
+    });
+
+    const monitor = new TmuxStateMonitor(tmux, 1_000, onUpdate, onError);
+    await monitor.start();
+
+    const firstForcePublish = monitor.forcePublish();
+    await expect.poll(() => firstForceStarted).toBe(true);
+
+    await tmux.zoomPane(initialPane.id);
+    await monitor.forcePublish();
+    const updatesAfterSecondForce = onUpdate.mock.calls.length;
+
+    releaseFirstForce?.();
+    await firstForcePublish;
+    await delay(20);
+    monitor.stop();
+
+    const zoomStatesAfterSecondForce = onUpdate.mock.calls
+      .slice(updatesAfterSecondForce)
+      .map(([snapshot]) => snapshot.sessions[0].windowStates[0].panes[0].zoomed);
+
+    expect(zoomStatesAfterSecondForce).not.toContain(false);
+    expect(onUpdate.mock.calls.at(-1)?.[0].sessions[0].windowStates[0].panes[0].zoomed).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
 });

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -246,6 +246,11 @@ test.describe("tmux-mobile browser behavior", () => {
       );
 
       await page.getByRole("button", { name: "Split H" }).click();
+      await expect
+        .poll(() => server.tmux.calls.some((call) => call.startsWith("splitWindow:")))
+        .toBe(true);
+      await expect(page.getByRole("button", { name: /^%\d+:/ })).toHaveCount(2);
+
       const zoomButton = page.getByRole("button", { name: "Zoom Pane" });
       await expect(zoomButton).toBeEnabled();
 

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -251,20 +251,21 @@ test.describe("tmux-mobile browser behavior", () => {
 
       const zoomButton = page.getByRole("button", { name: "Zoom Pane" });
       await expect(zoomButton).toBeEnabled();
-
-      const activePane = (await server.tmux.listPanes("main", 0)).find((pane) => pane.active);
-      if (!activePane) {
-        throw new Error("Expected an active pane in test harness");
-      }
-
-      await server.tmux.zoomPane(activePane.id);
+      const initialZoomCalls = server.tmux.calls.filter((call) => call.startsWith("zoomPane:")).length;
+      await zoomButton.click();
+      await expect
+        .poll(() => server.tmux.calls.filter((call) => call.startsWith("zoomPane:")).length)
+        .toBe(initialZoomCalls + 1);
       await expect(page.getByTestId("top-zoom-indicator")).toHaveAttribute("aria-label", "Pane zoom: on");
       await expect(page.getByTestId("active-pane-zoom-indicator")).toHaveAttribute(
         "aria-label",
         "Pane zoom: on"
       );
 
-      await server.tmux.zoomPane(activePane.id);
+      await zoomButton.click();
+      await expect
+        .poll(() => server.tmux.calls.filter((call) => call.startsWith("zoomPane:")).length)
+        .toBe(initialZoomCalls + 2);
       await expect(page.getByTestId("top-zoom-indicator")).toHaveAttribute("aria-label", "Pane zoom: off");
       await expect(page.getByTestId("active-pane-zoom-indicator")).toHaveAttribute(
         "aria-label",

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -304,6 +304,16 @@ test.describe("tmux-mobile browser behavior", () => {
 
       await page.getByTestId("drawer-toggle").click();
       await expect(page.locator(".drawer")).toBeVisible();
+      const mainSessionButton = page
+        .getByTestId("sessions-list")
+        .getByRole("button", { name: /^main\b/ });
+      await expect(mainSessionButton).toBeVisible();
+      await mainSessionButton.click();
+      await expect(page.locator(".drawer")).toHaveCount(0);
+
+      // Re-open drawer after explicit attach to pin UI state to "main".
+      await page.getByTestId("drawer-toggle").click();
+      await expect(page.locator(".drawer")).toBeVisible();
       await expect(page.getByTestId("active-pane-zoom-indicator")).toHaveAttribute(
         "aria-label",
         "Pane zoom: off"

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -234,6 +234,9 @@ test.describe("tmux-mobile browser behavior", () => {
     });
 
     test("shows zoom indicators for active pane in drawer and top bar", async ({ page }) => {
+      const initialPanes = await server.tmux.listPanes("main", 0);
+      await server.tmux.splitWindow(initialPanes[0].id, "h");
+
       await page.goto(`${server.baseUrl}/?token=${server.token}`);
       await expect(page.getByTestId("top-status-indicator")).toHaveClass(/ok/);
       await expect(page.getByTestId("top-zoom-indicator")).toHaveAttribute("aria-label", "Pane zoom: off");
@@ -244,11 +247,6 @@ test.describe("tmux-mobile browser behavior", () => {
         "aria-label",
         "Pane zoom: off"
       );
-
-      await page.getByRole("button", { name: "Split H" }).click();
-      await expect
-        .poll(() => server.tmux.calls.some((call) => call.startsWith("splitWindow:")))
-        .toBe(true);
       await expect(page.getByRole("button", { name: /^%\d+:/ })).toHaveCount(2);
 
       const zoomButton = page.getByRole("button", { name: "Zoom Pane" });

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -252,14 +252,19 @@ test.describe("tmux-mobile browser behavior", () => {
       const zoomButton = page.getByRole("button", { name: "Zoom Pane" });
       await expect(zoomButton).toBeEnabled();
 
-      await zoomButton.click();
+      const activePane = (await server.tmux.listPanes("main", 0)).find((pane) => pane.active);
+      if (!activePane) {
+        throw new Error("Expected an active pane in test harness");
+      }
+
+      await server.tmux.zoomPane(activePane.id);
       await expect(page.getByTestId("top-zoom-indicator")).toHaveAttribute("aria-label", "Pane zoom: on");
       await expect(page.getByTestId("active-pane-zoom-indicator")).toHaveAttribute(
         "aria-label",
         "Pane zoom: on"
       );
 
-      await zoomButton.click();
+      await server.tmux.zoomPane(activePane.id);
       await expect(page.getByTestId("top-zoom-indicator")).toHaveAttribute("aria-label", "Pane zoom: off");
       await expect(page.getByTestId("active-pane-zoom-indicator")).toHaveAttribute(
         "aria-label",

--- a/tests/e2e/harness/test-server.ts
+++ b/tests/e2e/harness/test-server.ts
@@ -25,6 +25,27 @@ export interface StartedE2EServer {
 export const startE2EServer = async (
   options: E2EServerOptions
 ): Promise<StartedE2EServer> => {
+  process.env.TMUX_MOBILE_VERBOSE_DEBUG = "1";
+
+  const formatLogPart = (value: unknown): string => {
+    if (typeof value === "string") {
+      return value;
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  };
+  const e2eLogger: Pick<Console, "log" | "error"> = {
+    log: (...args: unknown[]) => {
+      console.log(`[e2e-backend ${new Date().toISOString()}] ${args.map(formatLogPart).join(" ")}`);
+    },
+    error: (...args: unknown[]) => {
+      console.error(`[e2e-backend ${new Date().toISOString()}] ${args.map(formatLogPart).join(" ")}`);
+    }
+  };
+
   const token = "e2e-token";
   const authService = new AuthService(options.password, token);
   const tmux = new FakeTmuxGateway(options.sessions, {
@@ -49,10 +70,7 @@ export const startE2EServer = async (
     tmux,
     ptyFactory,
     authService,
-    logger: {
-      log: () => undefined,
-      error: () => undefined
-    }
+    logger: e2eLogger
   });
 
   await server.start();

--- a/tests/harness/fakeTmux.ts
+++ b/tests/harness/fakeTmux.ts
@@ -220,6 +220,12 @@ export class FakeTmuxGateway implements TmuxGateway {
     window.zoomed = !window.zoomed;
   }
 
+  public async isPaneZoomed(paneId: string): Promise<boolean> {
+    this.calls.push(`isPaneZoomed:${paneId}`);
+    const { window } = this.findByPane(paneId);
+    return window.zoomed;
+  }
+
   public async capturePane(paneId: string, lines: number): Promise<string> {
     this.calls.push(`capturePane:${paneId}:${lines}`);
     return `captured ${lines} lines for ${paneId}`;

--- a/tests/harness/fakeTmux.ts
+++ b/tests/harness/fakeTmux.ts
@@ -106,7 +106,7 @@ export class FakeTmuxGateway implements TmuxGateway {
         active: pane.active,
         width: pane.width,
         height: pane.height,
-        zoomed: window.zoomed
+        zoomed: window.zoomed && pane.active
       }))
     );
   }
@@ -236,8 +236,8 @@ export class FakeTmuxGateway implements TmuxGateway {
 
   public async isPaneZoomed(paneId: string): Promise<boolean> {
     this.calls.push(`isPaneZoomed:${paneId}`);
-    const { window } = this.findByPane(paneId);
-    return window.zoomed;
+    const { window, pane } = this.findByPane(paneId);
+    return window.zoomed && pane.active;
   }
 
   public async capturePane(paneId: string, lines: number): Promise<string> {

--- a/tests/harness/fakeTmux.ts
+++ b/tests/harness/fakeTmux.ts
@@ -15,6 +15,7 @@ interface WindowNode {
   index: number;
   name: string;
   active: boolean;
+  zoomed: boolean;
   panes: PaneNode[];
 }
 
@@ -42,6 +43,7 @@ const buildDefaultSession = (name: string): SessionNode => ({
       index: 0,
       name: "shell",
       active: true,
+      zoomed: false,
       panes: [
         {
           index: 0,
@@ -103,7 +105,8 @@ export class FakeTmuxGateway implements TmuxGateway {
         currentCommand: pane.command,
         active: pane.active,
         width: pane.width,
-        height: pane.height
+        height: pane.height,
+        zoomed: window.zoomed
       }))
     );
   }
@@ -140,6 +143,7 @@ export class FakeTmuxGateway implements TmuxGateway {
       index: nextIndex + 1,
       name: `win-${nextIndex + 1}`,
       active: true,
+      zoomed: false,
       panes: [
         {
           index: 0,
@@ -176,6 +180,7 @@ export class FakeTmuxGateway implements TmuxGateway {
     for (const pane of window.panes) {
       pane.active = false;
     }
+    window.zoomed = false;
     window.panes.push({
       index: window.panes.length,
       id: `%${paneCounter++}`,
@@ -208,6 +213,11 @@ export class FakeTmuxGateway implements TmuxGateway {
 
   public async zoomPane(paneId: string): Promise<void> {
     this.calls.push(`zoomPane:${paneId}`);
+    const { window } = this.findByPane(paneId);
+    for (const pane of window.panes) {
+      pane.active = pane.id === paneId;
+    }
+    window.zoomed = !window.zoomed;
   }
 
   public async capturePane(paneId: string, lines: number): Promise<string> {


### PR DESCRIPTION
Supersedes #26 for a fresh review context.

Closes #19

### What changed
- Add sticky zoom toggle persisted in localStorage
- Extend select_pane with optional stickyZoom and apply zoom on backend
- Update integration and e2e tests for sticky zoom behavior
- Include gated debug instrumentation to investigate CI-only sticky zoom flake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Implementation Details

**Backend Architecture:**
- Refactored TmuxStateMonitor with a new scheduling mechanism using recursive setTimeout instead of setInterval to improve reliability and prevent race conditions
- Introduced in-flight-token checks via forceGeneration counter to discard stale snapshot builds that occur during concurrent forcePublish operations
- Added comprehensive verbose logging infrastructure (gated by TMUX_MOBILE_VERBOSE_DEBUG environment variable) with helper functions to summarize client messages and tmux state for debugging CI flakes

**Protocol Changes:**
- Extended ControlClientMessage union to include optional stickyZoom flag on select_pane commands
- Added zoomed boolean field to TmuxPaneState across both backend and frontend type definitions
- Introduced new ControlServerMessage variants (attached, session_picker, tmux_state, scrollback, error, info) to support richer server-to-client communication

**Frontend:**
- Implemented sticky zoom state management with localStorage persistence and viewport-aware defaults (On for narrow screens, Off for wide screens)
- Added global debug infrastructure with Window augmentation (__tmuxMobileDebugEvents, __tmuxMobileDebugState) to support detailed runtime diagnostics via debug=1 URL query parameter
- Introduced dual zoom UI affordances: top-status pane zoom indicator (clickable button) and per-pane zoom indicators in drawer
- Integrated stickyZoom payload generation in pane selection logic to conditionally include stickyZoom: true based on feature state and pane activity

**Testing & Reliability:**
- Enhanced TmuxStateMonitor tests with new assertions for stale snapshot handling across multiple force publish sequences
- Added extensive e2e test suite for sticky zoom toggle covering:
  - Default state behavior on different screen sizes
  - localStorage persistence across page reloads
  - UI state synchronization (class changes, indicator text updates)
  - Diagnostic data collection (console logs, debug state, pane/session indicators)
- Integrated tests now validate select_pane with stickyZoom flag behavior, including edge cases (pre-zoomed panes, window-level zoom state)
- E2E test harness now enables verbose logging (TMUX_MOBILE_VERBOSE_DEBUG) to capture detailed backend behavior during test execution

**Test Harness Enhancements:**
- FakeTmuxGateway updated with zoomed window state tracking and isPaneZoomed query method
- Window zoom state properly reset on split operations to maintain consistency with tmux semantics
- Zoom state reflected in pane listing output to ensure frontend receives accurate state representation

## Architecture Improvements
The PR demonstrates improved resilience through elimination of setInterval in favor of recursive setTimeout scheduling, explicit handling of concurrent forcePublish operations via generation tokens, and comprehensive instrumentation for CI debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->