### PR TITLE
Silence default runtime logs and add logger tests

### DIFF
--- a/src/backend/util/file-logger.ts
+++ b/src/backend/util/file-logger.ts
@@ -19,7 +19,12 @@ export const createLogger = (
   logFilePath: string | undefined
 ): Pick<Console, "log" | "error"> => {
   if (!logFilePath) {
-    return console;
+    return {
+      log: () => undefined,
+      error: (...values: unknown[]) => {
+        console.error(...values);
+      }
+    };
   }
 
   const resolvedPath = path.resolve(logFilePath);

--- a/tests/backend/file-logger.test.ts
+++ b/tests/backend/file-logger.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createLogger } from "../../src/backend/util/file-logger.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("file logger", () => {
+  test("is quiet by default except for errors", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logger = createLogger(undefined);
+
+    logger.log("debug line");
+    logger.error("boom");
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith("boom");
+  });
+
+  test("writes log and error entries to file when debug path is provided", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tmux-mobile-logger-"));
+    const logPath = path.join(tmpDir, "debug.log");
+    const logger = createLogger(logPath);
+
+    logger.log("hello", { a: 1 });
+    logger.error(new Error("oops"));
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("[INFO] hello {\"a\":1}");
+    expect(content).toContain("[ERROR] Error: oops");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- make backend logger quiet by default so routine runtime traces do not print to stdout
- preserve error visibility by routing logger.error to stderr when debug logging is not enabled
- add backend tests that verify default quiet mode and file-backed debug logging behavior

## Validation
- npm test
- npm run typecheck